### PR TITLE
Verify load of DAGMC plugin when starting Trelis via output to comman…

### DIFF
--- a/export_dagmc_cmd/DAGMCExportCommand.cpp
+++ b/export_dagmc_cmd/DAGMCExportCommand.cpp
@@ -50,7 +50,7 @@ DAGMCExportCommand::DAGMCExportCommand() :
   if (console) {
     std::ostringstream load_message;
     load_message.str("");
-    load_message <<"Loading DAGMC export plugin..." << std::endl;
+    load_message <<"Loaded DAGMC export plugin." << std::endl;
     CubitInterface::get_cubit_message_handler()->print_error(load_message.str().c_str());
   }
 }

--- a/export_dagmc_cmd/DAGMCExportCommand.cpp
+++ b/export_dagmc_cmd/DAGMCExportCommand.cpp
@@ -45,6 +45,14 @@ DAGMCExportCommand::DAGMCExportCommand() :
   len_tol = 0.0;
   verbose_warnings = false;
   fatal_on_curves = false;
+
+  CubitMessageHandler *console = CubitInterface::get_cubit_message_handler();
+  if (console) {
+    std::ostringstream load_message;
+    load_message.str("");
+    load_message <<"Loading DAGMC export plugin..." << std::endl;
+    CubitInterface::get_cubit_message_handler()->print_error(load_message.str().c_str());
+  }
 }
 
 DAGMCExportCommand::~DAGMCExportCommand()


### PR DESCRIPTION
Upon opening Trelis, the string "Loading DAGMC export plugin..." is printed to the console for easy verification that the plugin has loaded.
