### PR TITLE
Add watertight opt

### DIFF
--- a/export_dagmc_cmd/CMakeLists.txt
+++ b/export_dagmc_cmd/CMakeLists.txt
@@ -21,6 +21,8 @@ include_directories(${CUBIT_INCLUDE_DIRS})
 find_package(MOAB REQUIRED)
 include_directories(${MOAB_INCLUDE_DIRS})
 
+include_directories("/home/shriwise/dagmc_blds/dagmc/include/")
+
 set(SRC
     MyPlugin.cpp
     MyPlugin.hpp
@@ -28,4 +30,4 @@ set(SRC
     DAGMCExportCommand.hpp)
 
 add_library(dagmc_export_plugin MODULE ${SRC})
-target_link_libraries(dagmc_export_plugin cubiti cubit_util cubit_geom ${MOAB_LIBRARIES})
+target_link_libraries(dagmc_export_plugin cubiti cubit_util cubit_geom /home/shriwise/dagmc_blds/dagmc/lib/libmakeWatertight.so ${MOAB_LIBRARIES})

--- a/export_dagmc_cmd/CMakeLists.txt
+++ b/export_dagmc_cmd/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories(${CUBIT_INCLUDE_DIRS})
 find_package(MOAB REQUIRED)
 include_directories(${MOAB_INCLUDE_DIRS})
 
-include_directories("${DAGMC_DIR}/include/")
+include_directories("${DAGMC_DIR}/../include/")
 
 set(SRC
     MyPlugin.cpp
@@ -30,4 +30,4 @@ set(SRC
     DAGMCExportCommand.hpp)
 
 add_library(dagmc_export_plugin MODULE ${SRC})
-target_link_libraries(dagmc_export_plugin cubiti cubit_util cubit_geom ${DAGMC_DIR}/lib/libmakeWatertight.so ${MOAB_LIBRARIES})
+target_link_libraries(dagmc_export_plugin cubiti cubit_util cubit_geom ${DAGMC_DIR}/libmakeWatertight.so ${MOAB_LIBRARIES})

--- a/export_dagmc_cmd/CMakeLists.txt
+++ b/export_dagmc_cmd/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories(${CUBIT_INCLUDE_DIRS})
 find_package(MOAB REQUIRED)
 include_directories(${MOAB_INCLUDE_DIRS})
 
-include_directories("/home/shriwise/dagmc_blds/dagmc/include/")
+include_directories("${DAGMC_DIR}/include/")
 
 set(SRC
     MyPlugin.cpp
@@ -30,4 +30,4 @@ set(SRC
     DAGMCExportCommand.hpp)
 
 add_library(dagmc_export_plugin MODULE ${SRC})
-target_link_libraries(dagmc_export_plugin cubiti cubit_util cubit_geom /home/shriwise/dagmc_blds/dagmc/lib/libmakeWatertight.so ${MOAB_LIBRARIES})
+target_link_libraries(dagmc_export_plugin cubiti cubit_util cubit_geom ${DAGMC_DIR}/lib/libmakeWatertight.so ${MOAB_LIBRARIES})

--- a/export_dagmc_cmd/DAGMCExportCommand.cpp
+++ b/export_dagmc_cmd/DAGMCExportCommand.cpp
@@ -19,7 +19,7 @@
 
 #include "SenseEntity.hpp"
 
-// MOAB includes[
+// MOAB includes
 #include "MBTagConventions.hpp"
 #include "moab/Core.hpp"
 #include "moab/Interface.hpp"
@@ -34,6 +34,10 @@
 #define CHK_MB_ERR_RET_MB(A,B)  if (moab::MB_SUCCESS != (B)) { \
   message << (A) << (B) << std::endl;                                   \
   return rval;                                                         \
+  }
+
+#define CHK_MB_ERR(A,B)  if (moab::MB_SUCCESS != (B)) { \
+  message << (A) << (B) << std::endl;                                   \
   }
 
 
@@ -251,8 +255,12 @@ void DAGMCExportCommand::teardown()
  
   CubitInterface::get_cubit_message_handler()->print_message(message.str().c_str()); 
   message.str("");
+
+  
+  moab::ErrorCode rval = mdbImpl->delete_mesh();
+  CHK_MB_ERR("Error cleaning up mesh instance.", rval);
   delete myGeomTool;
-  //  delete mdbImpl;
+
 
 }
 

--- a/export_dagmc_cmd/DAGMCExportCommand.cpp
+++ b/export_dagmc_cmd/DAGMCExportCommand.cpp
@@ -36,11 +36,6 @@
   return rval;                                                         \
   }
 
-#define CHK_MB_ERR(A,B)  if (moab::MB_SUCCESS != (B)) { \
-  message << (A) << (B) << std::endl;                                   \
-  }
-
-
 DAGMCExportCommand::DAGMCExportCommand() :
   geom_tag(0), id_tag(0), name_tag(0), category_tag(0), faceting_tol_tag(0), geometry_resabs_tag(0)
 {
@@ -161,7 +156,8 @@ bool DAGMCExportCommand::execute(CubitCommandData &data)
   rval = mdbImpl->write_file(filename.c_str());
   CHK_MB_ERR_RET("Error writing file: ",rval);
 
-  teardown();
+  rval = teardown();
+  CHK_MB_ERR_RET("Error tearing down export command.",rval);
   
   return result;
 }
@@ -236,7 +232,7 @@ moab::ErrorCode DAGMCExportCommand::create_tags()
   return rval;
 }
 
-void DAGMCExportCommand::teardown()
+moab::ErrorCode DAGMCExportCommand::teardown()
 {
   message  << "***** Faceting Summary Information *****" << std::endl;
   if (0 < failed_curve_count) {
@@ -258,9 +254,10 @@ void DAGMCExportCommand::teardown()
 
   
   moab::ErrorCode rval = mdbImpl->delete_mesh();
-  CHK_MB_ERR("Error cleaning up mesh instance.", rval);
+  CHK_MB_ERR_RET_MB("Error cleaning up mesh instance.", rval);
   delete myGeomTool;
 
+  return rval;
 
 }
 

--- a/export_dagmc_cmd/DAGMCExportCommand.hpp
+++ b/export_dagmc_cmd/DAGMCExportCommand.hpp
@@ -11,6 +11,9 @@
 #include "moab/Interface.hpp"
 #include "moab/GeomTopoTool.hpp"
 
+// make_watertight includes
+#include "mw_func.hpp"
+
 typedef std::map<RefEntity*, moab::EntityHandle> refentity_handle_map;
 typedef std::map<RefEntity*, moab::EntityHandle>::iterator refentity_handle_map_itor;
 
@@ -28,7 +31,8 @@ public:
   std::vector<std::string> get_syntax_help();
   std::vector<std::string> get_help();
   bool execute(CubitCommandData &data);
-
+  MakeWatertight* mw;
+  
 protected:
 
   moab::ErrorCode create_tags();
@@ -65,7 +69,8 @@ private:
   double len_tol;
   bool verbose_warnings;
   bool fatal_on_curves;
-
+  bool make_watertight;
+  
   int failed_curve_count;
   std::vector<int> failed_curves;
 

--- a/export_dagmc_cmd/DAGMCExportCommand.hpp
+++ b/export_dagmc_cmd/DAGMCExportCommand.hpp
@@ -12,7 +12,7 @@
 #include "moab/GeomTopoTool.hpp"
 
 // make_watertight includes
-#include "MakeWatertight.hpp"
+#include "make_watertight/MakeWatertight.hpp"
 
 typedef std::map<RefEntity*, moab::EntityHandle> refentity_handle_map;
 typedef std::map<RefEntity*, moab::EntityHandle>::iterator refentity_handle_map_itor;

--- a/export_dagmc_cmd/DAGMCExportCommand.hpp
+++ b/export_dagmc_cmd/DAGMCExportCommand.hpp
@@ -52,7 +52,7 @@ protected:
   moab::ErrorCode create_surface_facets(refentity_handle_map& surface_map,
                                         refentity_handle_map& vertex_map);
   moab::ErrorCode gather_ents(moab::EntityHandle gather_set);  
-  void teardown();
+  moab::ErrorCode teardown();
 
 private:
 

--- a/export_dagmc_cmd/DAGMCExportCommand.hpp
+++ b/export_dagmc_cmd/DAGMCExportCommand.hpp
@@ -12,7 +12,7 @@
 #include "moab/GeomTopoTool.hpp"
 
 // make_watertight includes
-#include "mw_func.hpp"
+#include "MakeWatertight.hpp"
 
 typedef std::map<RefEntity*, moab::EntityHandle> refentity_handle_map;
 typedef std::map<RefEntity*, moab::EntityHandle>::iterator refentity_handle_map_itor;

--- a/export_dagmc_cmd/README.md
+++ b/export_dagmc_cmd/README.md
@@ -1,7 +1,7 @@
 ```
 mkdir bld
 cd bld
-cmake .. -DCMAKE_PREFIX_PATH=/path/to/Trelis-16.0/bin -DCMAKE_INSTALL_BINARY_DIR=bin -DMOAB_DIR=/path/to/MOAB/lib
+cmake .. -DCMAKE_PREFIX_PATH=/path/to/Trelis-16.0/bin -DCMAKE_INSTALL_BINARY_DIR=bin -DMOAB_DIR=/path/to/MOAB/lib -DDAGMC_DIR=/path/to/DAGMC/
 make
 ```
 


### PR DESCRIPTION
This PR adds and option to export a watertight mesh by adding `make_watertight` to the end of the export DAGMC Trelis command.

Optional expansion on current work:
 - check the mesh for watertight-ness and report success rate to user on file write

The current build process for this is to add `-DDAGMC_DIR=/path/to/dagmc/lib/` to mimic the one used for MOAB. It does not rely on a .cmake file in DAGMC currently as it does for MOAB includes and libraries.