### PR TITLE
Add moab_setup.sh

### DIFF
--- a/setup_scripts/apt_setup.sh
+++ b/setup_scripts/apt_setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Install all simplest-level dependencies of DAGMC-Trelis that can be obtained via apt
+apt install -y autoconf libtool make mpich libblas-dev liblapack-dev libhdf5-dev cmake libarmadillo-dev

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+ 
+#MOAB Installation
+INSTALL_ROUTE=$HOME
+cd $INSTALL_ROUTE
+
+apt install -y autoconf libtool make mpich libblas-dev liblapack-dev libhdf5-dev cmake
+
+mkdir MOAB
+cd MOAB
+mkdir bld
+mkdir install
+git clone https://bitbucket.org/fathomteam/moab
+cd moab
+git checkout Version5.0
+autoreconf -fi
+cd ../bld
+../moab/configure --prefix=$INSTALL_ROUTE/MOAB/install --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial --enable-shared;
+make -j4
+make check
+make install
+printf 'export PATH=$PATH:%s/MOAB/install/bin' "$INSTALL_ROUTE">>/root/.bashrc
+export PATH=$PATH:$INSTALL_ROUTE/MOAB/install/bin
+printf 'export LD_LIBRARY_PATH=%s/MOAB/install/lib' "$INSTALL_ROUTE">>/root/.bashrc
+export LD_LIBRARY_PATH=$INSTALL_ROUTE/MOAB/install/lib

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -6,17 +6,19 @@ cd $INSTALL_ROOT
 mkdir MOAB
 cd MOAB
 mkdir bld
-mkdir install
+MOAB_INSTALL_DIR=$INSTALL_ROOT/MOAB/install
+mkdir $MOAB_INSTALL_DIR
 git clone https://bitbucket.org/fathomteam/moab
 cd moab
 git checkout Version5.0
 autoreconf -fi
 cd ../bld
-../moab/configure --prefix=$INSTALL_ROOT/MOAB/install --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial --enable-shared
+../moab/configure --prefix=$MOAB_INSTALL_DIR --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial --enable-shared
 make -j4
 make check
 make install
-printf 'export PATH=$PATH:$INSTALL_ROOT/MOAB/install/bin'>>$HOME/.bashrc
-export PATH=$PATH:$INSTALL_ROOT/MOAB/install/bin
-printf 'export LD_LIBRARY_PATH=$INSTALL_ROOT/MOAB/install/lib'>>$HOME/.bashrc
-export LD_LIBRARY_PATH=$INSTALL_ROOT/MOAB/install/lib
+printf 'Consider adding the following lines to .bashrc:\n'
+printf 'export PATH=$MOAB_INSTALL_DIR/bin:$PATH\n'
+export PATH=$MOAB_INSTALL_DIR/bin:$PATH
+printf 'export LD_LIBRARY_PATH=$MOAB_INSTALL_DIR/lib:$LD_LIBRARY_PATH\n'
+export LD_LIBRARY_PATH=$MOAB_INSTALL_DIR/lib:$LD_LIBRARY_PATH

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -19,7 +19,7 @@ cd ../bld
 make -j4
 make check
 make install
-printf 'export PATH=$PATH:%s/MOAB/install/bin' "$INSTALL_ROUTE">>/root/.bashrc
+printf 'export PATH=$PATH:%s/MOAB/install/bin' "$INSTALL_ROUTE">>$HOME/.bashrc
 export PATH=$PATH:$INSTALL_ROUTE/MOAB/install/bin
-printf 'export LD_LIBRARY_PATH=%s/MOAB/install/lib' "$INSTALL_ROUTE">>/root/.bashrc
+printf 'export LD_LIBRARY_PATH=%s/MOAB/install/lib' "$INSTALL_ROUTE">>$HOME/.bashrc
 export LD_LIBRARY_PATH=$INSTALL_ROUTE/MOAB/install/lib

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
  
 #MOAB Installation
-INSTALL_ROUTE=$HOME
-cd $INSTALL_ROUTE
-
-apt install -y autoconf libtool make mpich libblas-dev liblapack-dev libhdf5-dev cmake
-
+INSTALL_ROOT=$HOME
+cd $INSTALL_ROOT
 mkdir MOAB
 cd MOAB
 mkdir bld
@@ -15,11 +12,11 @@ cd moab
 git checkout Version5.0
 autoreconf -fi
 cd ../bld
-../moab/configure --prefix=$INSTALL_ROUTE/MOAB/install --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial --enable-shared;
+../moab/configure --prefix=$INSTALL_ROOT/MOAB/install --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial --enable-shared
 make -j4
 make check
 make install
-printf 'export PATH=$PATH:%s/MOAB/install/bin' "$INSTALL_ROUTE">>$HOME/.bashrc
-export PATH=$PATH:$INSTALL_ROUTE/MOAB/install/bin
-printf 'export LD_LIBRARY_PATH=%s/MOAB/install/lib' "$INSTALL_ROUTE">>$HOME/.bashrc
-export LD_LIBRARY_PATH=$INSTALL_ROUTE/MOAB/install/lib
+printf 'export PATH=$PATH:$INSTALL_ROOT/MOAB/install/bin'>>$HOME/.bashrc
+export PATH=$PATH:$INSTALL_ROOT/MOAB/install/bin
+printf 'export LD_LIBRARY_PATH=$INSTALL_ROOT/MOAB/install/lib'>>$HOME/.bashrc
+export LD_LIBRARY_PATH=$INSTALL_ROOT/MOAB/install/lib


### PR DESCRIPTION
Add a simple script to download, build, and install MOAB v5.0 and its dependencies. Future additions will refine this script and add scripts to sequentially build all dependencies of the DAGMC-Trelis plugin.