### PR TITLE
MOAB Setup: Use eigen3

### DIFF
--- a/setup_scripts/apt_setup.sh
+++ b/setup_scripts/apt_setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 #Install all simplest-level dependencies of DAGMC-Trelis that can be obtained via apt
-apt install -y autoconf libtool make mpich libblas-dev liblapack-dev libhdf5-dev cmake libarmadillo-dev
+apt install -y libeigen3-dev libtool make mpich libhdf5-dev cmake libarmadillo-dev

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -13,7 +13,9 @@ git clone https://bitbucket.org/fathomteam/moab
 cd moab
 git checkout Version5.0
 cd ../bld
-cmake ../moab -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF
+cmake ../moab -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR \
+ -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON \
+ -DENABLE_BLASLAPACK=OFF
 make -j4
 make check
 make install

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -11,9 +11,8 @@ mkdir $MOAB_INSTALL_DIR
 git clone https://bitbucket.org/fathomteam/moab
 cd moab
 git checkout Version5.0
-autoreconf -fi
 cd ../bld
-../moab/configure --prefix=$MOAB_INSTALL_DIR --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial --enable-shared
+cmake ../moab -DCMAKE_INSTALL_PREFIX=$INSTALL_ROOT/MOAB/install -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON
 make -j4
 make check
 make install

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -13,7 +13,7 @@ git clone https://bitbucket.org/fathomteam/moab
 cd moab
 git checkout Version5.0
 cd ../bld
-cmake ../moab -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON
+cmake ../moab -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF
 make -j4
 make check
 make install

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -9,10 +9,11 @@ mkdir bld
 MOAB_INSTALL_DIR=$INSTALL_ROOT/MOAB/install
 mkdir $MOAB_INSTALL_DIR
 git clone https://bitbucket.org/fathomteam/moab
+
 cd moab
 git checkout Version5.0
 cd ../bld
-cmake ../moab -DCMAKE_INSTALL_PREFIX=$INSTALL_ROOT/MOAB/install -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON
+cmake ../moab -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON
 make -j4
 make check
 make install


### PR DESCRIPTION
Adjust moab_setup.sh and apt_setup.sh to use cmake and eigen3 instead of Autotools, BLAS, and LAPACK.