### PR TITLE
Add dagmc setup

### DIFF
--- a/setup_scripts/apt_setup.sh
+++ b/setup_scripts/apt_setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 #Install all simplest-level dependencies of DAGMC-Trelis that can be obtained via apt
-apt install -y autoconf libtool make mpich libblas-dev liblapack-dev libhdf5-dev cmake libarmadillo-dev
+apt install -y libeigen3-dev libtool make mpich libhdf5-dev cmake libarmadillo-dev

--- a/setup_scripts/dagmc_setup.sh
+++ b/setup_scripts/dagmc_setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#DAGMC Installation
+INSTALL_ROOT=$HOME
+cd $INSTALL_ROOT
+mkdir dagmc
+cd dagmc
+git clone https://github.com/svalinn/DAGMC
+cd DAGMC
+git checkout develop
+cd ..
+mkdir bld
+DAGMC_INSTALL_DIR=$INSTALL_ROOT/dagmc/install
+mkdir $DAGMC_INSTALL_DIR
+cd bld
+cmake ../DAGMC -DCMAKE_INSTALL_PREFIX=$DAGMC_INSTALL_DIR
+make 
+make install
+printf '\nConsider adding the following lines to .bashrc:\n'
+printf 'export PATH=$DAGMC_INSTALL_DIR/bin:$PATH\n'
+export PATH=$DAGMC_INSTALL_DIR/bin:$PATH
+printf 'export LD_LIBRARY_PATH=$DAGMC_INSTALL_DIR/lib:$LD_LIBRARY_PATH\n'
+export LD_LIBRARY_PATH=$DAGMC_INSTALL_DIR/lib:$LD_LIBRARY_PATH

--- a/setup_scripts/dagmc_setup.sh
+++ b/setup_scripts/dagmc_setup.sh
@@ -10,14 +10,17 @@ cd DAGMC
 git checkout develop
 cd ..
 mkdir bld
+
 DAGMC_INSTALL_DIR=$INSTALL_ROOT/dagmc/install
+MOAB_CONFIG_DIR=$INSTALL_ROOT/MOAB/install/lib/cmake/MOAB
 mkdir $DAGMC_INSTALL_DIR
 cd bld
-cmake ../DAGMC -DCMAKE_INSTALL_PREFIX=$DAGMC_INSTALL_DIR
+cmake ../DAGMC -DCMAKE_INSTALL_PREFIX=$DAGMC_INSTALL_DIR -DMOAB_CMAKE_CONFIG=$MOAB_CONFIG_DIR
 make 
 make install
-printf '\nConsider adding the following lines to .bashrc:\n'
-printf 'export PATH=$DAGMC_INSTALL_DIR/bin:$PATH\n'
-export PATH=$DAGMC_INSTALL_DIR/bin:$PATH
-printf 'export LD_LIBRARY_PATH=$DAGMC_INSTALL_DIR/lib:$LD_LIBRARY_PATH\n'
-export LD_LIBRARY_PATH=$DAGMC_INSTALL_DIR/lib:$LD_LIBRARY_PATH
+
+printf '\nConsider running the following lines and adding them to .bashrc:\n'
+printf "export PATH=$DAGMC_INSTALL_DIR/bin"':$PATH\n'
+printf "export LD_LIBRARY_PATH=$DAGMC_INSTALL_DIR/lib"':$LD_LIBRARY_PATH\n'
+
+cd $INSTALL_ROOT

--- a/setup_scripts/dagmc_setup.sh
+++ b/setup_scripts/dagmc_setup.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 
 #DAGMC Installation
-INSTALL_ROOT=$HOME
+source install_dir.sh
+mkdir $INSTALL_ROOT
 cd $INSTALL_ROOT
 mkdir dagmc
 cd dagmc
-git clone https://github.com/svalinn/DAGMC
-cd DAGMC
-git checkout develop
-cd ..
+git clone -b develop https://github.com/svalinn/DAGMC
 mkdir bld
 
 DAGMC_INSTALL_DIR=$INSTALL_ROOT/dagmc/install
@@ -18,6 +16,7 @@ cd bld
 cmake ../DAGMC -DCMAKE_INSTALL_PREFIX=$DAGMC_INSTALL_DIR -DMOAB_CMAKE_CONFIG=$MOAB_CONFIG_DIR
 make 
 make install
+run-parts ../install/tests
 
 printf '\nConsider running the following lines and adding them to .bashrc:\n'
 printf "export PATH=$DAGMC_INSTALL_DIR/bin"':$PATH\n'

--- a/setup_scripts/install_dir.sh
+++ b/setup_scripts/install_dir.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#This should be changed to match whichever directory you would like to use
+INSTALL_ROOT=$HOME/cnerg

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
  
 #MOAB Installation
-INSTALL_ROOT=$HOME
+source install_dir.sh
+mkdir $INSTALL_ROOT
 cd $INSTALL_ROOT
 mkdir MOAB
 cd MOAB

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -13,7 +13,9 @@ git clone https://bitbucket.org/fathomteam/moab
 cd moab
 git checkout Version5.0
 cd ../bld
-cmake ../moab -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF
+cmake ../moab -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR \
+ -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON \
+ -DENABLE_BLASLAPACK=OFF
 make -j4
 make check
 make install

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -11,9 +11,8 @@ mkdir $MOAB_INSTALL_DIR
 git clone https://bitbucket.org/fathomteam/moab
 cd moab
 git checkout Version5.0
-autoreconf -fi
 cd ../bld
-../moab/configure --prefix=$MOAB_INSTALL_DIR --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial --enable-shared
+cmake ../moab -DCMAKE_INSTALL_PREFIX=$INSTALL_ROOT/MOAB/install -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON
 make -j4
 make check
 make install

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -11,7 +11,6 @@ mkdir $MOAB_INSTALL_DIR
 git clone https://bitbucket.org/fathomteam/moab
 
 cd moab
-git checkout Version5.0
 cd ../bld
 cmake ../moab -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR \
  -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON \
@@ -19,8 +18,13 @@ cmake ../moab -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR \
 make -j4
 make check
 make install
-printf '\nConsider adding the following lines to .bashrc:\n'
-printf 'export PATH=$MOAB_INSTALL_DIR/bin:$PATH\n'
-export PATH=$MOAB_INSTALL_DIR/bin:$PATH
-printf 'export LD_LIBRARY_PATH=$MOAB_INSTALL_DIR/lib:$LD_LIBRARY_PATH\n'
-export LD_LIBRARY_PATH=$MOAB_INSTALL_DIR/lib:$LD_LIBRARY_PATH
+
+#Bandaid code, to make master branch work neatly with DAGMC in script
+echo "set(MOAB_INCLUDE_DIRS "$MOAB_INSTALL_DIR/include" "/usr/include/eigen3")"\
+>>$MOAB_INSTALL_DIR/lib/cmake/MOAB/MOABConfig.cmake
+
+printf '\nConsider running the following commands, and adding them to .bashrc:\n'
+printf "export PATH=$MOAB_INSTALL_DIR/bin:"'$PATH\n'
+printf "export LD_LIBRARY_PATH=$MOAB_INSTALL_DIR/lib:"'$LD_LIBRARY_PATH\n'
+
+cd $INSTALL_ROOT

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -13,7 +13,7 @@ git clone https://bitbucket.org/fathomteam/moab
 cd moab
 git checkout Version5.0
 cd ../bld
-cmake ../moab -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON
+cmake ../moab -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF
 make -j4
 make check
 make install

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -19,7 +19,7 @@ cmake ../moab -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR \
 make -j4
 make check
 make install
-printf 'Consider adding the following lines to .bashrc:\n'
+printf '\nConsider adding the following lines to .bashrc:\n'
 printf 'export PATH=$MOAB_INSTALL_DIR/bin:$PATH\n'
 export PATH=$MOAB_INSTALL_DIR/bin:$PATH
 printf 'export LD_LIBRARY_PATH=$MOAB_INSTALL_DIR/lib:$LD_LIBRARY_PATH\n'

--- a/setup_scripts/moab_setup.sh
+++ b/setup_scripts/moab_setup.sh
@@ -9,10 +9,11 @@ mkdir bld
 MOAB_INSTALL_DIR=$INSTALL_ROOT/MOAB/install
 mkdir $MOAB_INSTALL_DIR
 git clone https://bitbucket.org/fathomteam/moab
+
 cd moab
 git checkout Version5.0
 cd ../bld
-cmake ../moab -DCMAKE_INSTALL_PREFIX=$INSTALL_ROOT/MOAB/install -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON
+cmake ../moab -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/ -DENABLE_HDF5=ON
 make -j4
 make check
 make install


### PR DESCRIPTION
Adds dagmc_setup.sh to setup_scripts directory, for quick installation of DAGMC in a "fresh" development environment. Includes changes made in currently-open PR "MOAB Setup: Use eigen3"; it may be expedient to review those first. 