### PR TITLE
CMake Updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,22 @@ endif ()
 
 # MCNP importer
 if (BUILD_MCNP_IMPORTER)
+
+  #===============================================================================
+  # Update mcnp2cad submodule as neeeded
+  #===============================================================================
+  find_package(Git)
+  if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+    message(STATUS "Submodule update")
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      RESULT_VARIABLE GIT_SUBMOD_RESULT)
+    if(NOT GIT_SUBMOD_RESULT EQUAL 0)
+      message(FATAL_ERROR "git submodule update --init failed with \
+          ${GIT_SUBMOD_RESULT}, please checkout submodules")
+    endif()
+  endif()
+
   message(STATUS "Building MCNP importer")
   add_definitions(-DBUILD_MCNP_IMPORT=ON)
   set(STANDALONE_MCNP2CAD  OFF CACHE BOOL "")

--- a/README.md
+++ b/README.md
@@ -126,15 +126,6 @@ library.
 Build the Plugin
 ================
 
-The plugin depends on another external repository called mcnp2cad. mcnp2cad is
-available in this repo as a git submodule, and it can be obtained with these
-commands:
-
-```
-cd ${HOME}/plugin-build/Trelis-plugin
-git submodule update --init
-```
-
 The following commands show how to build the plugin itself. The `CUBIT_ROOT`
 variable must point to the location of `Trelis`, while the `DAGMC_DIR` variable
 must point to the location of DAGMC.
@@ -149,6 +140,18 @@ cmake ../Trelis-plugin -DCUBIT_ROOT=/opt/Trelis-16.5 \
                        -DCMAKE_INSTALL_PREFIX=${HOME}/plugin-build
 make -j`grep -c processor /proc/cpuinfo`
 make install
+```
+
+### Submodules
+
+The plugin depends on another external repository called mcnp2cad. mcnp2cad is
+available in this repo as a git submodule. It is pulled automatically during the
+`cmake` configuration step above. Alternatively, it can be manually updated with
+the following commands:
+
+```
+cd ${HOME}/plugin-build/Trelis-plugin
+git submodule update --init
 ```
 
 Create the Tarball


### PR DESCRIPTION
Some updates to the CMake here:

  - Adding the `mcnp2cad` project as a submodule

     This is a pretty clean way to make sure we're getting the version of `mcnp2cad` we need when building this tool. I've added a CMake block that will update this submodule if the MCNP importer is enabled, meaning no additional git commands are needed when cloning the plugin.
  - Place build if `iGeom` before `mcnp2cad`

    To successfully build the plugin with the mcnp importer enabled, a build with `BUILD_IGEOM=ON` and `BUILD_MCNP_IMPORTER=OFF` must first be performed. Building the `iGeom` target first (now also aliased as `IGEOM_LIB`) allows us to provide this target to `mcnp2cad` and perform the build in one step without modifications to the default CMake settings.

**Note: This PR is dependent on https://github.com/svalinn/mcnp2cad/pull/69**