### PR TITLE
Fix MACRO that checks for MOAB error

### DIFF
--- a/export_dagmc_cmd/DAGMCExportCommand.cpp
+++ b/export_dagmc_cmd/DAGMCExportCommand.cpp
@@ -34,7 +34,7 @@
 
 #define CHK_MB_ERR_RET_MB(A,B)  if (moab::MB_SUCCESS != (B)) { \
   message << (A) << (B) << std::endl;                                   \
-  return rval;                                                         \
+  return (B);                                                         \
   }
 
 DAGMCExportCommand::DAGMCExportCommand() :


### PR DESCRIPTION
Fixes #88 

This never caused an error in practice, but was incorrect.