### PR TITLE
Updating for PyNE Submodule in DAGMC

### DIFF
--- a/scripts/linux_share_build.sh
+++ b/scripts/linux_share_build.sh
@@ -83,7 +83,9 @@ function build_dagmc(){
     mkdir -pv DAGMC/bld
     cd DAGMC
     git clone https://github.com/svalinn/DAGMC -b develop
-    cd bld
+    cd DAGMC
+    git submodule update --init
+    cd ../bld
     cmake ../DAGMC -DMOAB_DIR=${PLUGIN_ABS_PATH}/moab \
                 -DBUILD_UWUW=ON \
                 -DBUILD_TALLY=OFF \


### PR DESCRIPTION
This replaces #90 with the hopes that this overcomes the lack of access to the necessary secrets, and still gets this quick fix in ahead of #86.