### PR TITLE
Separate build install readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ To view the available command line options for the MCNP importer, type
 
 Similarly for the DAGMC exporter, type ```help dagmc``` in the Cubit command line.
 
-Some sample files have been included in the [test_plugin](https://github.com/svalinn/Cubit-plugin/tree/develop/test_plugin)
+Some sample files have been included in the [test_plugin](test_plugin)
 directory of this repository for testing the command line usage.
 
 
 Building the plugin
 ===================
 
-Building the plugin from source is also [possible](https://github.com/svalinn/Cubit-plugin/tree/develop/README_dev.md) but only recommended for developers.
+Building the plugin from source is also [possible](README_dev.md) but only recommended for developers.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Svalinn plugins and command extensions for Cubit
 =================================================
 
-The plugin has been tested and is confirmed to work with various Corefoam Cubit
-versions up to 2021.5 and versions of Cubit up to 15.8.
+The plugin has been tested and is confirmed to work with versions of Corefoam
+Cubit up to 2021.5 and versions of Cubit up to 15.8.
 
 Install Cubit
 ==============

--- a/README.md
+++ b/README.md
@@ -1,235 +1,56 @@
 Svalinn plugins and command extensions for Cubit
 =================================================
 
-**Beta:** This software is currently under early development. It has been
-demonstrated to work on a wide range of problems, but the build system is not
-finalized.
-
-The plugin has been tested and is confirmed to work with various Cubit versions 17.1 up to 2020.2. 
-
-Prerequisites
-=============
-
-In order to build the plugin, you must have access to Cubit and the Cubit SDK.
-Additionally, the following system packages must be present on
-your computer:
-
-* EIGEN3
-* HDF5
-
-On Ubuntu, these packages can be obtained by running
-
-```
-sudo apt install libeigen3-dev libhdf5-dev
-```
-
-The following packages are not available from the package manager and must be
-built yourself:
-
-* MOAB 5.1.0
-* DAGMC
+The plugin has been tested and is confirmed to work with various Corefoam Cubit
+versions up to 2021.5 and versions of Cubit up to 15.8.
 
 Install Cubit
 ==============
 
-Cubit can be installed by obtaining the Cubit `.deb` package and installing it
-with the package manager; i.e.
+Cubit or Corefoam Cubit can be installed by following the instructions on the
+relevant website. Cubit is available for Sandia and US National labs users
+while Coreform Cubit is available via comerical licenses or freeley available
+for students and hobbyists as Cubit Learn.
 
-```
-sudo dpkg -i Cubit_DEB.deb
-```
+- [Download Cubit](https://cubit.sandia.gov/downloads.html) from Sandia
+- [Download Corefoam Cubit](https://coreform.com/products/downloads/) from Corefoam
 
-This installs Cubit to `/opt/Coreform-Cubit-VERSION` or `/opt/Trelis-VERSION` for older versions.
+<details>
+    <summary><b>Expand</b> - Ubuntu terminal commands for Corefoam Cubit</summary>
+    <pre><code class="language-html">
+    sudo apt update
+    sudo apt-get install wget
+    wget -O coreform-cubit-2021.5.deb https://f002.backblazeb2.com/file/cubit-downloads/Coreform-Cubit/Releases/Linux/Coreform-Cubit-2021.5%2B15962_5043ef39-Lin64.deb
+    sudo dpkg -i coreform-cubit-2021.5.deb 
+    </code></pre>
+</details>
 
-For Cubit versions older than 2021, one needs to manually install the provided SDK
 
-### Note 
-There is also a bug (or some other unknown issue) in come Cubit SDK which requires a
-file in the Cubit SDK to be modified. The following commands show how to make
-this change. (This issue is not present in Cubit 17, so these commands do not
-need to be run for Cubit 17.)
+Install Plugin
+==============
 
-```
-cd PATH_TO_CUBIT/bin
-sudo cp -pv CubitExport.cmake CubitExport.cmake.orig
-sudo sed -i "s/\"cubit_util\" \"showviz_base\"/\"cubit_util\"/" CubitExport.cmake
-```
+The Plugin can be downloaded from the [Release](https://github.com/svalinn/Cubit-plugin/releases)
+section of this repository. Operating system specific assets are created with
+each release and can be download for various Operating systems (Ubuntu 18, 20
+and MacOS 10.15).
 
-Notes on Build Instructions
-===========================
+After downloading the compressed tgz file the contents should be uncompress to
+your Cubit folder.
+<details>
+    <summary><b>Expand</b> - Ubuntu terminal commands for Ubuntu 20.04</summary>
+    <pre><code class="language-html">
+    wget https://github.com/svalinn/Cubit-plugin/releases/download/0.1.0/svalinn-plugin_ubuntu-20.04_cubit_2021.5.tgz
+    sudo tar -xzvf svalinn-plugin_ubuntu-20.04_cubit_2021.5.tgz -C /opt/Coreform-Cubit-2021.5
+    </code></pre>
+</details>
 
-A non-source directory build is recommended. These build instructions assume
-that the plugin build will take place in the `${HOME}/plugin-build` directory,
-and they assume that the Cubit-plugin repo has been cloned into
-`${HOME}/plugin-build/Cubit-plugin`.
-
-**Before building anything, ensure that the `LD_LIBRARY_PATH` environment
-variable is empty**. 
-
-```bash
-unset LD_LIBRARY_PATH
-plugin, and if it is not empty it can only cause problems. Ensure that it
-remains empty when running Cubit as well.
-```
-
-Build MOAB
-==========
-
-MOAB must be built with HDF5 enabled. On Ubuntu 18.04, HDF5 is located in the
-`/usr/lib/x86_64-linux-gnu/hdf5/serial` directory, but it may be located
-somewhere else on other flavors or versions of Linux. MOAB should be built with
-the Eigen matrix algebra library instead of LAPACK. The
-`_GLIBCXX_USE_CXX11_ABI=0` flag is required for compatibility with Cubit.
-
-The following commands show how to correctly build the MOAB dependency. If HDF5
-is located somewhere other than `/usr/lib/x86_64-linux-gnu/hdf5/serial`, then
-replace the directory with the correct one.
-
-```
-cd ${HOME}/plugin-build
-mkdir -pv moab/bld
-cd moab
-git clone https://bitbucket.org/fathomteam/moab -b Version5.1.0
-cd moab
-autoreconf -fi
-cd ../bld
-../moab/configure CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0 \
-                  --enable-shared \
-                  --enable-optimize \
-                  --disable-debug \
-                  --disable-blaslapack \
-                  --with-eigen3=/usr/include/eigen3 \
-                  --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial \
-                  --prefix=${HOME}/plugin-build/moab
-make -j`grep -c processor /proc/cpuinfo`
-make install
-```
-
-Build DAGMC
-===========
-
-The following commands show how to build the DAGMC dependency. The `uwuw` and
-`make_watertight` features should be turned on, while other features should be
-turned off. The `MOAB_DIR` variable should point to the location of the
-previously-built MOAB library. The `_GLIBCXX_USE_CXX11_ABI=0` flag is once again
-required.
-
-The following commands show how to correctly build the DAGMC dependency.
-
-```
-cd ${HOME}/plugin-build
-mkdir -pv DAGMC/bld
-cd DAGMC
-git clone https://github.com/svalinn/DAGMC -b develop
-cd bld
-cmake ../DAGMC -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0 \
-               -DMOAB_DIR=${HOME}/plugin-build/moab \
-               -DBUILD_UWUW=ON \
-               -DBUILD_TALLY=OFF \
-               -DBUILD_BUILD_OBB=OFF \
-               -DBUILD_MAKE_WATERTIGHT=ON \
-               -DBUILD_SHARED_LIBS=ON \
-               -DBUILD_STATIC_LIBS=OFF \
-               -DCMAKE_BUILD_TYPE=Release \
-               -DCMAKE_INSTALL_PREFIX=${HOME}/plugin-build/DAGMC
-make -j`grep -c processor /proc/cpuinfo`
-make install
-```
-
-Build the Plugin
-================
-
-The following commands show how to build the plugin itself. The `CUBIT_ROOT`
-variable should point to the location of Cubit. The `DAGMC_DIR` variable should
-point to the location of the previously-built DAGMC library.
-
-```
-cd ${HOME}/plugin-build
-mkdir -pv bld
-cd bld
-cmake ../Cubit-plugin -DCUBIT_ROOT=PATH_TO_CUBIT \
-                       -DDAGMC_DIR=${HOME}/plugin-build/DAGMC \
-                       -DCMAKE_BUILD_TYPE=Release \
-                       -DCMAKE_INSTALL_PREFIX=${HOME}/plugin-build
-make -j`grep -c processor /proc/cpuinfo`
-make install
-```
-
-### Submodules
-
-The plugin depends on another external repository called mcnp2cad. mcnp2cad is
-available in this repo as a git submodule. It is pulled by default during the
-`cmake` configuration step above.
-
-If a custom version of mcnp2cad is needed, this behavior pulling can be disabled
-by adding `-DUPDATE_SUBMODULES=OFF` to the `cmake` configuration. mcnp2cad can
-then be manually updated with the following commands:
-
-```
-cd ${HOME}/plugin-build/Cubit-plugin
-git submodule update --init
-```
-
-Create the Tarball
-==================
-
-The following commands show how to create the tarall for the plugin. Once again,
-the location of HDF5 might be different than what is presented here depending on
-what flavor or version of Linux is being used.
-
-```
-# Set up the directory which will contain the libraries
-cd ${HOME}/plugin-build
-mkdir -p pack/bin/plugins/svalinn
-cd pack/bin/plugins/svalinn
-
-# Copy all needed libraries into current directory
-cp -pPv /usr/lib/x86_64-linux-gnu/libhdf5_serial.so.100* .
-cp -pPv ${HOME}/plugin-build/moab/lib/libMOAB.so* .
-cp -pPv ${HOME}/plugin-build/DAGMC/lib/libdagmc.so* .
-cp -pPv ${HOME}/plugin-build/DAGMC/lib/libmakeWatertight.so* .
-cp -pPv ${HOME}/plugin-build/DAGMC/lib/libpyne_dagmc.so* .
-cp -pPv ${HOME}/plugin-build/DAGMC/lib/libuwuw.so* .
-cp -pPv ${HOME}/plugin-build/lib/* .
-chmod 644 *
-
-# The resulting shared library objects require an update to their RPATH (runtime path) 
-# attribute to ensure that the correct set of libraries is discovered when starting 
-# Cubit and loading the plugin library.
-patchelf --set-rpath PATH_TO_CUBIT/bin/plugins/svalinn libMOAB.so
-patchelf --set-rpath PATH_TO_CUBIT/bin/plugins/svalinn libdagmc.so
-patchelf --set-rpath PATH_TO_CUBIT/bin/plugins/svalinn libmakeWatertight.so
-patchelf --set-rpath PATH_TO_CUBIT/bin/plugins/svalinn libpyne_dagmc.so
-patchelf --set-rpath PATH_TO_CUBIT/bin/plugins/svalinn libuwuw.so
-
-# Create the Svalinn plugin tarball
-cd ..
-ln -sv svalinn/libsvalinn_plugin.so .
-cd ../..
-tar --sort=name -czvf svalinn-plugin-17.1.tgz bin
-mv -v svalinn-plugin-17.1.tgz ..
-cd ..
-rm -rf pack
-```
-
-The Svalinn plugin tarball should now be located at
-`${HOME}/plugin-build/svalinn-plugin-17.1.tgz`.
-
-Install the Plugin
-==================
-
-To install the plugin, simply run
-
-```
-cd PATH_TO_CUBIT
-sudo tar -xzvf ${HOME}/plugin-build/svalinn-plugin.tgz
-```
 
 Test the Plugin
 ===============
 
-Run `coreform_cubit`. If the plugin was installed correctly, after the Cubit GUI
-finishes loading, the following output should appear in the Cubit command line:
+Run ```coreform_cubit``` from the command line. If the plugin was installed
+correctly, after the Cubit GUI finishes loading, the following output should
+appear in the Cubit command line:
 
 ```
 Loaded Svalinn plugin.
@@ -243,32 +64,22 @@ Cubit>
 
 If this output does not appear, then the plugin was not installed correctly.
 
+
+Usage within Cubit
+==================
+
+The DAGMC plugin commands should now be accessable via the Cubit command line.
+
 To view the available command line options for the MCNP importer, type
-`help mcnp` in the Cubit command line. Similarly for the DAGMC exporter, type
-`help dagmc` in the Cubit command line.
+```help mcnp``` in the Cubit command line.
 
-Some sample files have been included in the `test_plugin` directory of this
-repository. Navigate to that directory, then run `coreform_cubit`. In the Cubit command
-line, type `import mcnp test.i`. This should result in the MCNP geometry and
-material mapping contained within the MCNP input file `test.i` being imported
-into Cubit.
+Similarly for the DAGMC exporter, type ```help dagmc``` in the Cubit command line.
 
-Next, run `export acis test.sat overwrite attributes_on`. This will save the
-geometry in ACIS format to `test.sat`.
+Some sample files have been included in the [test_plugin](https://github.com/svalinn/Cubit-plugin/tree/develop/test_plugin)
+directory of this repository for testing the command line usage.
 
-Lastly, run
-`export dagmc "test.h5m" faceting_tolerance 1e-3 make_watertight verbose`. This
-will facet the geometry and save it in a format that can be used by DAGMC.
 
-Test the Plugin (Command Line Mode)
-===================================
+Building the plugin
+===================
 
-The plugin can also be run in command line mode, without needing to load the
-Cubit GUI. The file `test.jou` in the `test_plugin` directory contains the five
-commands mentioned in the previous section of this readme. To execute these
-commands in command line mode, run
-`coreform_cubit -batch -nographics -nojournal test.jou` from the regular command line.
-
-It is through this command line interface that one would replicate the workflows
-of years past which involved the now-defunct `mcnp2cad` and `dagmc_preproc`
-executables.
+Building the plugin from source is also [possible](https://github.com/svalinn/Cubit-plugin/tree/develop/README_dev.md) but only recommended for developers.

--- a/README.md
+++ b/README.md
@@ -48,22 +48,24 @@ your Cubit folder.
 Test the Plugin
 ===============
 
-Run ```coreform_cubit``` from the command line. If the plugin was installed
-correctly, after the Cubit GUI finishes loading, the following output should
-appear in the Cubit command line:
+Load Cubit by running ```coreform_cubit``` from the command line. After the
+Cubit GUI finishes loading, run the following command in the Cubit command line:
 
 ```
-Loaded Svalinn plugin.
--- DAGMC export command available.
--- iGeom_test command available.
--- MCNP import command available.
-Journaled Command: undo on
+help dagmc
+```
 
-Cubit>
+If the plugin was installed correctly you should see the following text appear.
+
+```
+Help for words: dagmc.
+
+export dagmc <filename> [faceting_tolerance <faceting tolerance>] [length_tolerance <length tolerance>]
+     [normal_tolerance <normal tolerance>] [make_watertight] [verbose]
+     [fatal_on_curves]
 ```
 
 If this output does not appear, then the plugin was not installed correctly.
-
 
 Usage within Cubit
 ==================

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Svalinn plugins and command extensions for Cubit
 =================================================
 
-The plugin has been tested and is confirmed to work with versions of Corefoam
+The plugin has been tested and is confirmed to work with versions of Coreform 
 Cubit up to 2021.5 and versions of Cubit up to 15.8.
 
 Install Cubit

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ and MacOS 10.15).
 After downloading the compressed tgz file the contents should be uncompress to
 your Cubit folder.
 <details>
-    <summary><b>Expand</b> - Ubuntu terminal commands for Ubuntu 20.04</summary>
+    <summary><b>Expand</b> - Terminal commands for Ubuntu 20.04</summary>
     <pre><code class="language-html">
     wget https://github.com/svalinn/Cubit-plugin/releases/download/0.1.0/svalinn-plugin_ubuntu-20.04_cubit_2021.5.tgz
     sudo tar -xzvf svalinn-plugin_ubuntu-20.04_cubit_2021.5.tgz -C /opt/Coreform-Cubit-2021.5

--- a/README_dev.md
+++ b/README_dev.md
@@ -2,7 +2,7 @@ Building the DAGMC Cubit plugin from source
 ===========================================
 
 This guide is intended for developers and maintainers of the Cubit plugin.
-For installation instructions see the [installation guide](README_dev.md).
+For installation instructions see the [installation guide](README.md).
 
 
 Prerequisites

--- a/README_dev.md
+++ b/README_dev.md
@@ -62,18 +62,22 @@ mkdir -pv moab/bld
 cd moab
 git clone https://bitbucket.org/fathomteam/moab -b 5.3.0
 cd moab
-autoreconf -fi
-cd ../bld
-../moab/configure CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0 \
-                  --enable-shared \
-                  --enable-optimize \
-                  --disable-debug \
-                  --disable-blaslapack \
-                  --with-eigen3=/usr/include/eigen3 \
-                  --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial \
-                  --prefix=${HOME}/plugin-build/moab
-make -j`grep -c processor /proc/cpuinfo`
+# patching MOAB CMakeLists.txt to use default find(HDF5)
+$SED -i "s/HDF5_MOAB/HDF5/" CMakeLists.txt
+cd ..
+#end of patch
+cd bld
+cmake ../moab -DENABLE_HDF5=ON \
+        -DHDF5_ROOT=$HDF5_PATH \
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} \
+        -DENABLE_BLASLAPACK=OFF \
+        -DENABLE_FORTRAN=OFF \
+        $CMAKE_ADDITIONAL_FLAGS \
+        -DCMAKE_INSTALL_PREFIX=${PLUGIN_ABS_PATH}/moab
+make
 make install
+cd ../..
+rm -rf moab/moab moab/bld
 ```
 
 Build DAGMC

--- a/README_dev.md
+++ b/README_dev.md
@@ -2,7 +2,7 @@ Building the DAGMC Cubit plugin from source
 ===========================================
 
 This guide is intended for developers and maintainers of the Cubit plugin.
-For installation instructions see the [installation guide](https://github.com/svalinn/Cubit-plugin/tree/develop/README_dev.md).
+For installation instructions see the [installation guide](README_dev.md).
 
 
 Prerequisites

--- a/README_dev.md
+++ b/README_dev.md
@@ -60,7 +60,7 @@ replace the directory with the correct one.
 cd ${HOME}/plugin-build
 mkdir -pv moab/bld
 cd moab
-git clone https://bitbucket.org/fathomteam/moab -b Version5.1.0
+git clone https://bitbucket.org/fathomteam/moab -b 5.3.0
 cd moab
 autoreconf -fi
 cd ../bld

--- a/README_dev.md
+++ b/README_dev.md
@@ -1,11 +1,9 @@
-Svalinn plugins and command extensions for Cubit
-=================================================
+Building the DAGMC Cubit plugin from source
+===========================================
 
-**Beta:** This software is currently under early development. It has been
-demonstrated to work on a wide range of problems, but the build system is not
-finalized.
+This guide is intended for developers and maintainers of the Cubit plugin.
+For installation instructions see the [installation guide](https://github.com/svalinn/Cubit-plugin/tree/develop/README_dev.md).
 
-The plugin has been tested and is confirmed to work with various Cubit versions 17.1 up to 2021.5. 
 
 Prerequisites
 =============

--- a/README_dev.md
+++ b/README_dev.md
@@ -1,0 +1,208 @@
+Svalinn plugins and command extensions for Cubit
+=================================================
+
+**Beta:** This software is currently under early development. It has been
+demonstrated to work on a wide range of problems, but the build system is not
+finalized.
+
+The plugin has been tested and is confirmed to work with various Cubit versions 17.1 up to 2021.5. 
+
+Prerequisites
+=============
+
+In order to build the plugin, you must have access to Cubit and the Cubit SDK.
+Additionally, the following system packages must be present on
+your computer:
+
+* EIGEN3
+* HDF5
+
+On Ubuntu, these packages can be obtained by running
+
+```bash
+sudo apt install libeigen3-dev libhdf5-dev
+```
+
+The following packages are not available from the package manager and must be
+built yourself:
+
+* [MOAB 5.3.0](https://bitbucket.org/fathomteam/moab/src/master/)
+* [DAGMC 3.2](https://github.com/svalinn/DAGMC)
+
+
+Notes on Build Instructions
+===========================
+
+A non-source directory build is recommended. These build instructions assume
+that the plugin build will take place in the `${HOME}/plugin-build` directory,
+and they assume that the Cubit-plugin repo has been cloned into
+`${HOME}/plugin-build/Cubit-plugin`.
+
+**Before building anything, ensure that the `LD_LIBRARY_PATH` environment
+variable is empty**. 
+
+```bash
+unset LD_LIBRARY_PATH
+plugin, and if it is not empty it can only cause problems. Ensure that it
+remains empty when running Cubit as well.
+```
+
+Build MOAB
+==========
+
+MOAB must be built with HDF5 enabled. On Ubuntu 18.04, HDF5 is located in the
+`/usr/lib/x86_64-linux-gnu/hdf5/serial` directory, but it may be located
+somewhere else on other flavors or versions of Linux. MOAB should be built with
+the Eigen matrix algebra library instead of LAPACK. The
+`_GLIBCXX_USE_CXX11_ABI=0` flag is required for compatibility with Cubit.
+
+The following commands show how to correctly build the MOAB dependency. If HDF5
+is located somewhere other than `/usr/lib/x86_64-linux-gnu/hdf5/serial`, then
+replace the directory with the correct one.
+
+```bash
+cd ${HOME}/plugin-build
+mkdir -pv moab/bld
+cd moab
+git clone https://bitbucket.org/fathomteam/moab -b Version5.1.0
+cd moab
+autoreconf -fi
+cd ../bld
+../moab/configure CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0 \
+                  --enable-shared \
+                  --enable-optimize \
+                  --disable-debug \
+                  --disable-blaslapack \
+                  --with-eigen3=/usr/include/eigen3 \
+                  --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial \
+                  --prefix=${HOME}/plugin-build/moab
+make -j`grep -c processor /proc/cpuinfo`
+make install
+```
+
+Build DAGMC
+===========
+
+The following commands show how to build the DAGMC dependency. The `uwuw` and
+`make_watertight` features should be turned on, while other features should be
+turned off. The `MOAB_DIR` variable should point to the location of the
+previously-built MOAB library. The `_GLIBCXX_USE_CXX11_ABI=0` flag is once again
+required.
+
+The following commands show how to correctly build the DAGMC dependency.
+
+```bash
+cd ${HOME}/plugin-build
+mkdir -pv DAGMC/bld
+cd DAGMC
+git clone https://github.com/svalinn/DAGMC -b develop
+cd bld
+cmake ../DAGMC -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0 \
+               -DMOAB_DIR=${HOME}/plugin-build/moab \
+               -DBUILD_UWUW=ON \
+               -DBUILD_TALLY=OFF \
+               -DBUILD_BUILD_OBB=OFF \
+               -DBUILD_MAKE_WATERTIGHT=ON \
+               -DBUILD_SHARED_LIBS=ON \
+               -DBUILD_STATIC_LIBS=OFF \
+               -DCMAKE_BUILD_TYPE=Release \
+               -DCMAKE_INSTALL_PREFIX=${HOME}/plugin-build/DAGMC
+make -j`grep -c processor /proc/cpuinfo`
+make install
+```
+
+Build the Plugin
+================
+
+The following commands show how to build the plugin itself. The `CUBIT_ROOT`
+variable should point to the location of Cubit. The `DAGMC_DIR` variable should
+point to the location of the previously-built DAGMC library.
+
+```bash
+cd ${HOME}/plugin-build
+mkdir -pv bld
+cd bld
+cmake ../Cubit-plugin -DCUBIT_ROOT=PATH_TO_CUBIT \
+                       -DDAGMC_DIR=${HOME}/plugin-build/DAGMC \
+                       -DCMAKE_BUILD_TYPE=Release \
+                       -DCMAKE_INSTALL_PREFIX=${HOME}/plugin-build
+make -j`grep -c processor /proc/cpuinfo`
+make install
+```
+
+Submodules
+==========
+
+The plugin depends on another external repository called mcnp2cad. mcnp2cad is
+available in this repo as a git submodule. It is pulled by default during the
+`cmake` configuration step above.
+
+If a custom version of mcnp2cad is needed, this behavior pulling can be disabled
+by adding `-DUPDATE_SUBMODULES=OFF` to the `cmake` configuration. mcnp2cad can
+then be manually updated with the following commands:
+
+```bash
+cd ${HOME}/plugin-build/Cubit-plugin
+git submodule update --init
+```
+
+Create the Tarball
+==================
+
+The following commands show how to create the tarall for the plugin. Once again,
+the location of HDF5 might be different than what is presented here depending on
+what flavor or version of Linux is being used.
+
+
+Set up the directory which will contain the libraries
+```bash
+cd ${HOME}/plugin-build
+mkdir -p pack/bin/plugins/svalinn
+cd pack/bin/plugins/svalinn
+```
+
+Copy all needed libraries into current directory
+```bash
+cp -pPv /usr/lib/x86_64-linux-gnu/libhdf5_serial.so.100* .
+cp -pPv ${HOME}/plugin-build/moab/lib/libMOAB.so* .
+cp -pPv ${HOME}/plugin-build/DAGMC/lib/libdagmc.so* .
+cp -pPv ${HOME}/plugin-build/DAGMC/lib/libmakeWatertight.so* .
+cp -pPv ${HOME}/plugin-build/DAGMC/lib/libpyne_dagmc.so* .
+cp -pPv ${HOME}/plugin-build/DAGMC/lib/libuwuw.so* .
+cp -pPv ${HOME}/plugin-build/lib/* .
+chmod 644 *
+```
+
+The resulting shared library objects require an update to their RPATH (runtime path) 
+attribute to ensure that the correct set of libraries is discovered when starting 
+Cubit and loading the plugin library.
+```bash
+patchelf --set-rpath PATH_TO_CUBIT/bin/plugins/svalinn libMOAB.so
+patchelf --set-rpath PATH_TO_CUBIT/bin/plugins/svalinn libdagmc.so
+patchelf --set-rpath PATH_TO_CUBIT/bin/plugins/svalinn libmakeWatertight.so
+patchelf --set-rpath PATH_TO_CUBIT/bin/plugins/svalinn libpyne_dagmc.so
+patchelf --set-rpath PATH_TO_CUBIT/bin/plugins/svalinn libuwuw.so
+```
+
+Create the Svalinn plugin tarball
+```bash
+cd ..
+ln -sv svalinn/libsvalinn_plugin.so .
+cd ../..
+tar --sort=name -czvf svalinn-plugin-17.1.tgz bin
+mv -v svalinn-plugin-17.1.tgz ..
+cd ..
+rm -rf pack
+```
+
+The Svalinn plugin tarball should now be located at
+`${HOME}/plugin-build/svalinn-plugin-17.1.tgz`.
+
+Install the Plugin
+==================
+
+To install the plugin, simply run
+```bash
+cd PATH_TO_CUBIT
+sudo tar -xzvf ${HOME}/plugin-build/svalinn-plugin.tgz
+```

--- a/README_dev.md
+++ b/README_dev.md
@@ -37,12 +37,10 @@ and they assume that the Cubit-plugin repo has been cloned into
 `${HOME}/plugin-build/Cubit-plugin`.
 
 **Before building anything, ensure that the `LD_LIBRARY_PATH` environment
-variable is empty**. 
+variable is empty**. Ensure that it remains empty when running Cubit as well.
 
 ```bash
 unset LD_LIBRARY_PATH
-plugin, and if it is not empty it can only cause problems. Ensure that it
-remains empty when running Cubit as well.
 ```
 
 Build MOAB

--- a/README_dev.md
+++ b/README_dev.md
@@ -125,6 +125,7 @@ cd bld
 cmake ../Cubit-plugin -DCUBIT_ROOT=PATH_TO_CUBIT \
                        -DDAGMC_DIR=${HOME}/plugin-build/DAGMC \
                        -DCMAKE_BUILD_TYPE=Release \
+                       -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0 \
                        -DCMAKE_INSTALL_PREFIX=${HOME}/plugin-build
 make -j`grep -c processor /proc/cpuinfo`
 make install

--- a/scripts/unix_share_build.sh
+++ b/scripts/unix_share_build.sh
@@ -110,7 +110,7 @@ function build_moab() {
     cd ${PLUGIN_ABS_PATH}
     mkdir -pv moab/bld
     cd moab
-    git clone https://bitbucket.org/fathomteam/moab -b Version5.1.0
+    git clone https://bitbucket.org/fathomteam/moab -b 5.3.0
     cd moab
     # patching MOAB CMakeLists.txt to use default find(HDF5)
     $SED -i "s/HDF5_MOAB/HDF5/" CMakeLists.txt

--- a/test_plugin/README.md
+++ b/test_plugin/README.md
@@ -1,0 +1,19 @@
+Test the Plugin (Command Line Mode)
+===================================
+
+Some sample files have been included in the ```test_plugin``` directory of this
+repository.
+
+To test the loading of a sample MCNP geometry and materials:
+
+- Download or clone the repository
+- Tthen navigate to the directory with ```cd Cubit-plugin/test_plugin```
+- Then run the ```coreform_cubit``` command
+- In the Cubit command line, type ```import mcnp test.i```
+- Now save the geometry in ACIS format (.sat file) by entering ```export acis test.sat overwrite attributes_on``` in the Cubit command line.
+- Finally enter ```export dagmc "test.h5m" faceting_tolerance 1e-3 make_watertight verbose``` into the cubit command line which will facet the geometry and save it in a format that can be used by DAGMC (.h5m file).
+
+The same test can also be carried out from the regular command line without
+loading the Cubit GUI by running journals (.jou files).
+
+- In the regular commmand line enter ```coreform_cubit -batch -nographics -nojournal test.jou```


### PR DESCRIPTION
As discussed in the DAGMC community meeting today.

The Readme contains more advanced build instructions that the average user will not need.

Therefore the README has been split into two parts, one for simple installation and one for the more complex build.

The testing section was also in need on a split and the more advanced part of the testing is has been moved to the test_plugin folder where it will render as the main readme for that url

Just worth mentioning that the README files have links between them which will not work on this PR as they link to the develop branch version of themselves :-)
