### PR TITLE
Forcing use of python3 in CI

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -29,12 +29,16 @@ jobs:
             os: ubuntu-18.04
         exclude:
           - cubit: 17.1.0
-            os: ubuntu-20.04      
+            os: ubuntu-20.04 
 
     name: 'Cubit Svalinn Plugin ${{ matrix.cubit }} Build for ${{ matrix.os }}'
 
 
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
       - uses: actions/checkout@v2
 
       - name: Environment Variables

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -35,10 +35,6 @@ jobs:
 
 
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
       - uses: actions/checkout@v2
 
       - name: Environment Variables

--- a/scripts/unix_share_build.sh
+++ b/scripts/unix_share_build.sh
@@ -134,7 +134,7 @@ function build_dagmc(){
     cd ${PLUGIN_ABS_PATH}
     mkdir -pv DAGMC/bld
     cd DAGMC
-    git clone https://github.com/svalinn/DAGMC -b develop
+    git clone https://github.com/bam241/DAGMC -b py3
     cd bld
     cmake ../DAGMC -DMOAB_DIR=${PLUGIN_ABS_PATH}/moab \
                 -DBUILD_UWUW=ON \


### PR DESCRIPTION
This should enforce python3 in CI and should comply with new DAGMC requirement