### PR TITLE
added os_version to unix build macro

### DIFF
--- a/.github/workflows/unix_linux.yml
+++ b/.github/workflows/unix_linux.yml
@@ -89,6 +89,7 @@ jobs:
           echo "HDF5_PATH=${HDF5_PATH}" >> $GITHUB_ENV
 
           echo "OS=${{ matrix.os }}" >> $GITHUB_ENV
+          echo "OS_VERSION=${{ matrix.os_version }}" >> $GITHUB_ENV
           echo "CMAKE_ADDITIONAL_FLAGS=-DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0" >> $GITHUB_ENV
 
           echo "CUBIT_PKG=${BASE}-${SUFFIX}.${EXT}" >> $GITHUB_ENV

--- a/scripts/unix_share_build.sh
+++ b/scripts/unix_share_build.sh
@@ -12,6 +12,7 @@
 # - SUDO : specify the command prefix to run as root (if any)
 # - SED : command to run sed (usually sed for linux, gsed for mac)
 # - OS : reference to the Operating system, used to name the plugin tarball (and when using setup_var() function)
+# - OS_VERSION : reference to the Operating system version, used to name the plugin tarball (and when using setup_var() function)
 
 set -ex
 
@@ -271,9 +272,9 @@ function linux_build_plugin_pkg(){
     cd ..
     ln -sv svalinn/libsvalinn_plugin.so .
     cd ../..
-    tar --sort=name -czvf svalinn-plugin_${OS}_cubit_$1.tgz bin
-    chmod 666 svalinn-plugin_${OS}_cubit_$1.tgz
-    cp svalinn-plugin_${OS}_cubit_$1.tgz $SCRIPTPATH/release/
+    tar --sort=name -czvf svalinn-plugin_${OS}-${OS_VERSION}_cubit_$1.tgz bin
+    chmod 666 svalinn-plugin_${OS}-${OS_VERSION}_cubit_$1.tgz
+    cp svalinn-plugin_${OS}-${OS_VERSION}_cubit_$1.tgz $SCRIPTPATH/release/
 }
 
 function mac_build_plugin_pkg(){
@@ -300,7 +301,7 @@ function mac_build_plugin_pkg(){
     cd ..
     ln -sv svalinn/libsvalinn_plugin.so .
     cd ../..
-    tar -czvf svalinn-plugin_${OS}_cubit_${1}.tgz MacOS
-    chmod 666 svalinn-plugin_${OS}_cubit_$1.tgz
-    cp svalinn-plugin_${OS}_cubit_$1.tgz $SCRIPTPATH/release/
+    tar -czvf svalinn-plugin_${OS}-${OS_VERSION}_cubit_${1}.tgz MacOS
+    chmod 666 svalinn-plugin_${OS}-${OS_VERSION}_cubit_$1.tgz
+    cp svalinn-plugin_${OS}-${OS_VERSION}_cubit_$1.tgz $SCRIPTPATH/release/
 }

--- a/scripts/unix_share_build.sh
+++ b/scripts/unix_share_build.sh
@@ -272,9 +272,10 @@ function linux_build_plugin_pkg(){
     cd ..
     ln -sv svalinn/libsvalinn_plugin.so .
     cd ../..
-    tar --sort=name -czvf svalinn-plugin_${OS}-${OS_VERSION}_cubit_$1.tgz bin
-    chmod 666 svalinn-plugin_${OS}-${OS_VERSION}_cubit_$1.tgz
-    cp svalinn-plugin_${OS}-${OS_VERSION}_cubit_$1.tgz $SCRIPTPATH/release/
+    PLUGIN_FILENAME=svalinn-plugin_${OS}-${OS_VERSION}_cubit_$1.tgz
+    tar --sort=name -czvf ${PLUGIN_FILENAME} bin
+    chmod 666 ${PLUGIN_FILENAME}
+    cp ${PLUGIN_FILENAME} $SCRIPTPATH/release/
 }
 
 function mac_build_plugin_pkg(){
@@ -301,7 +302,8 @@ function mac_build_plugin_pkg(){
     cd ..
     ln -sv svalinn/libsvalinn_plugin.so .
     cd ../..
-    tar -czvf svalinn-plugin_${OS}-${OS_VERSION}_cubit_${1}.tgz MacOS
-    chmod 666 svalinn-plugin_${OS}-${OS_VERSION}_cubit_$1.tgz
-    cp svalinn-plugin_${OS}-${OS_VERSION}_cubit_$1.tgz $SCRIPTPATH/release/
+    PLUGIN_FILENAME=svalinn-plugin_${OS}-${OS_VERSION}_cubit_$1.tgz
+    tar -czvf ${PLUGIN_FILENAME} MacOS
+    chmod 666 ${PLUGIN_FILENAME}
+    cp ${PLUGIN_FILENAME} $SCRIPTPATH/release/
 }


### PR DESCRIPTION
This PR into a feature branch is one option for getting ```os_version``` from the github action into the unix_share_build script as suggested in the review for #115

The only down side I can see with this approach is that the unix_share_build script currently makes use of ```lsb_release``` to find the Linux version. So perhaps this should also be removed?