### PR TITLE
add mac os for all cubit versions

### DIFF
--- a/.github/workflows/unix_mac.yml
+++ b/.github/workflows/unix_mac.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         cubit: [17.1.0, 2021.4, 2021.5]
         os: [macos]
-        os_version: [10.15]
+        os_version: [10.15, 11]
 
     name: 'Cubit ${{ matrix.cubit }} Build for ${{ matrix.os }} ${{ matrix.os_version }} of Svalinn Plugin'
 


### PR DESCRIPTION
While chatting with @andergray we noticed Cubit Plugin was not available for Mac OS 11

It looks like Mac OS 11 is available as a runner so I thought it is worth trying to build on that OS

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
