### PR TITLE
removing MACOS version in plugin tarball

### DIFF
--- a/.github/workflows/unix_mac.yml
+++ b/.github/workflows/unix_mac.yml
@@ -19,14 +19,12 @@ env:
 
 jobs:
   main:
-    runs-on: ${{ matrix.os }}-${{ matrix.os_version }}
+    runs-on: macos-10.15
     strategy:
       matrix:
         cubit: [17.1.0, 2021.4, 2021.5]
-        os: [macos]
-        os_version: [10.15]
 
-    name: 'Cubit ${{ matrix.cubit }} Build for ${{ matrix.os }} ${{ matrix.os_version }} of Svalinn Plugin'
+    name: 'Cubit ${{ matrix.cubit }} Build for MacOS of Svalinn Plugin'
 
     steps:
       - uses: actions/checkout@v2
@@ -60,8 +58,7 @@ jobs:
           echo "CUBIT_PATH=/Applications/${CUBIT_BASE_NAME}.app/Contents" >> $GITHUB_ENV
           echo "COREFORM_BASE_URL=${COREFORM_BASE_URL}/MacOS/" >> $GITHUB_ENV
 
-          echo "OS=${{ matrix.os }}" >> $GITHUB_ENV
-          echo "OS_VERSION=${{ matrix.os_version }}" >> $GITHUB_ENV
+          echo "OS=macos" >> $GITHUB_ENV
           echo "CMAKE_ADDITIONAL_FLAGS=-DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0" >> $GITHUB_ENV
 
           echo "CUBIT_PKG=${BASE}-${SUFFIX}.${EXT}" >> $GITHUB_ENV
@@ -126,8 +123,8 @@ jobs:
         name: Upload artifact for CI
         uses: actions/upload-artifact@v2
         with:
-          name: svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
-          path: ${{ github.workspace }}/release/svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
+          name: svalinn-plugin_${{env.OS}}_cubit_${{ matrix.cubit }}.tgz
+          path: ${{ github.workspace }}/release/svalinn-plugin_${{env.OS}}_cubit_${{ matrix.cubit }}.tgz
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn` 
     
       - if: github.event_name == 'release'
@@ -135,6 +132,6 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ github.workspace }}/release/svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
-          asset_name: svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
+          file: ${{ github.workspace }}/release/svalinn-plugin_${{env.OS}}_cubit_${{ matrix.cubit }}.tgz
+          asset_name: svalinn-plugin_${{env.OS}}_cubit_${{ matrix.cubit }}.tgz
           tag: ${{ github.ref }}

--- a/scripts/unix_share_build.sh
+++ b/scripts/unix_share_build.sh
@@ -302,7 +302,7 @@ function mac_build_plugin_pkg(){
     cd ..
     ln -sv svalinn/libsvalinn_plugin.so .
     cd ../..
-    PLUGIN_FILENAME=svalinn-plugin_${OS}-${OS_VERSION}_cubit_$1.tgz
+    PLUGIN_FILENAME=svalinn-plugin_${OS}_cubit_$1.tgz
     tar -czvf ${PLUGIN_FILENAME} MacOS
     chmod 666 ${PLUGIN_FILENAME}
     cp ${PLUGIN_FILENAME} $SCRIPTPATH/release/


### PR DESCRIPTION
I just tried our most recent macOS tarball (cubit 2021.5), build with MacOS 10.15, on my desktop (MacOS 11.4). it worked just fine.

I think we can assume that those tarball are compatible with virtual all version of MacOS..

therefore I removed the mention of the MacOS used to build it in order to avoid confusing our users.

this should replace #120 