### PR TITLE
Add exclusion path to limit the extend of our CI, to only targeted file changes

### DIFF
--- a/.github/workflows/unix_linux.yml
+++ b/.github/workflows/unix_linux.yml
@@ -6,11 +6,21 @@ on:
   pull_request:
     branches:
       - develop
-      - master
+    paths-ignore:
+      - '.github/workflows/windows.yml'
+      - '.github/workflows/unix_linux.yml'
+      - '*.md'
+      - 'LICENSE'
+
   push:
     branches:
       - develop
-      - master
+    paths-ignore:
+      - '.github/workflows/windows.yml'
+      - '.github/workflows/unix_linux.yml'
+      - '*.md'
+      - 'LICENSE'
+
   release:
     types: # This configuration does not affect the page_build event above
       - created

--- a/.github/workflows/unix_linux.yml
+++ b/.github/workflows/unix_linux.yml
@@ -8,7 +8,7 @@ on:
       - develop
     paths-ignore:
       - '.github/workflows/windows.yml'
-      - '.github/workflows/unix_linux.yml'
+      - '.github/workflows/unix_mac.yml'
       - '*.md'
       - 'LICENSE'
 
@@ -17,7 +17,7 @@ on:
       - develop
     paths-ignore:
       - '.github/workflows/windows.yml'
-      - '.github/workflows/unix_linux.yml'
+      - '.github/workflows/unix_mac.yml'
       - '*.md'
       - 'LICENSE'
 

--- a/.github/workflows/unix_mac.yml
+++ b/.github/workflows/unix_mac.yml
@@ -9,7 +9,7 @@ on:
       - master
     paths-ignore:
       - '.github/workflows/windows.yml'
-      - '.github/workflows/unix_mac.yml'
+      - '.github/workflows/unix_linux.yml'
       - '*.md'
       - 'LICENSE'
 
@@ -19,7 +19,7 @@ on:
       - master
     paths-ignore:
       - '.github/workflows/windows.yml'
-      - '.github/workflows/unix_mac.yml'
+      - '.github/workflows/unix_linux.yml'
       - '*.md'
       - 'LICENSE'
 

--- a/.github/workflows/unix_mac.yml
+++ b/.github/workflows/unix_mac.yml
@@ -7,10 +7,22 @@ on:
     branches:
       - develop
       - master
+    paths-ignore:
+      - '.github/workflows/windows.yml'
+      - '.github/workflows/unix_mac.yml'
+      - '*.md'
+      - 'LICENSE'
+
   push:
     branches:
       - develop
       - master
+    paths-ignore:
+      - '.github/workflows/windows.yml'
+      - '.github/workflows/unix_mac.yml'
+      - '*.md'
+      - 'LICENSE'
+
   release:
     types: # This configuration does not affect the page_build event above
       - created


### PR DESCRIPTION
this will exclude change not on the code or the corresponding GitHub Action workflow to trigger some part of the CI.

Docs change are now excluded from workflows,
Linux workflow changes will only trigger Linux CI same goes for MacOS...