### PR TITLE
Changing MCNP import syntax to lowercase.

### DIFF
--- a/import_mcnp_cmd/MCNPImp.cpp
+++ b/import_mcnp_cmd/MCNPImp.cpp
@@ -48,7 +48,7 @@ std::vector<std::string> MCNPImp::get_syntax()
   // format. Full documentation on the command specification syntax can be
   // found in the documentation.
   std::string syntax =
-      "import MCNP "
+      "import mcnp "
       "<string:label='filename',help='<filename>'> "
       "[verbose] [debug] [debug_output] [debug_input] "
       "[extra_effort] [skip_mats] [skip_merge] "


### PR DESCRIPTION
Windows users have reported that the MCNP import command only works when using an uppercase "MCNP". This changes the syntax to allow a lowercase name in the input command for consistency between Windows and Linux as well as consistency in the input syntax between the importer and the exporter.