### PR TITLE
Adding cubit 2021.11

### DIFF
--- a/.github/workflows/unix_linux.yml
+++ b/.github/workflows/unix_linux.yml
@@ -179,3 +179,4 @@ jobs:
           file: ${{ github.workspace }}/release/svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
           asset_name: svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
           tag: ${{ github.ref }}
+          overwrite: true

--- a/.github/workflows/unix_linux.yml
+++ b/.github/workflows/unix_linux.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cubit: [2021.4, 2021.5]
+        cubit: [2021.4, 2021.5, 2021.11]
         os: [ubuntu]
         os_version: [20.04, 21.04]
         include:

--- a/.github/workflows/unix_linux.yml
+++ b/.github/workflows/unix_linux.yml
@@ -85,6 +85,10 @@ jobs:
             BASE=Coreform-Cubit-2021.5%2B15962_5043ef39
             CUBIT_BASE_NAME=Coreform-Cubit-2021.5
             HDF5_PATH=/usr/local/HDF_Group/HDF5/1.12.0
+          elif [ "${{ matrix.cubit }}" == "2021.11" ]; then
+            BASE=Coreform-Cubit-2021.11%2B21637_35609873
+            CUBIT_BASE_NAME=Coreform-Cubit-2021.11
+            HDF5_PATH=/usr/local/HDF_Group/HDF5/1.12.0
           fi
 
           SUFFIX=Lin64

--- a/.github/workflows/unix_linux.yml
+++ b/.github/workflows/unix_linux.yml
@@ -44,6 +44,10 @@ jobs:
             os_version: '10.10'  # using a 'string' here as the 0 gets rounded away otherwise
             cubit: 2021.5
 
+          - os: debian
+            os_version: '10.10'  # using a 'string' here as the 0 gets rounded away otherwise
+            cubit: 2021.11
+
    
     name: 'Cubit ${{ matrix.cubit }} Build for ${{ matrix.os }} ${{ matrix.os_version }} of Svalinn Plugin'
 

--- a/.github/workflows/unix_mac.yml
+++ b/.github/workflows/unix_mac.yml
@@ -151,3 +151,4 @@ jobs:
           file: ${{ github.workspace }}/release/svalinn-plugin_${{env.OS}}_cubit_${{ matrix.cubit }}.tgz
           asset_name: svalinn-plugin_${{env.OS}}_cubit_${{ matrix.cubit }}.tgz
           tag: ${{ github.ref }}
+          overwrite: true

--- a/.github/workflows/unix_mac.yml
+++ b/.github/workflows/unix_mac.yml
@@ -59,6 +59,10 @@ jobs:
             BASE=Coreform-Cubit-2021.5%2B15962_5043ef39
             CUBIT_BASE_NAME=Coreform-Cubit-2021.5
             HDF5_PATH=/usr/local/HDF_Group/HDF5/1.12.0
+          elif [ "${{ matrix.cubit }}" == "2021.11" ]; then
+            BASE=Coreform-Cubit-2021.11%2B21637_35609873
+            CUBIT_BASE_NAME=Coreform-Cubit-2021.11
+            HDF5_PATH=/usr/local/HDF_Group/HDF5/1.12.0
           fi
 
           SUFFIX=Mac64

--- a/.github/workflows/unix_mac.yml
+++ b/.github/workflows/unix_mac.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        cubit: [17.1.0, 2021.4, 2021.5]
+        cubit: [17.1.0, 2021.4, 2021.5, 2021.11]
 
     name: 'Cubit ${{ matrix.cubit }} Build for MacOS of Svalinn Plugin'
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        cubit: [17.1.0, 2021.3,  2021.4,  2021.5]
+        cubit: [17.1.0, 2021.3,  2021.4,  2021.5, 2021.11]
 
     name: 'Cubit Svalinn Plugin ${{ matrix.cubit }} Build for Windows'
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -213,4 +213,4 @@ jobs:
           file: C:/Users/runneradmin/svalinn_plugin_windows_${{ matrix.cubit }}.zip
           asset_name: svalinn_plugin_windows_${{ matrix.cubit }}.zip
           tag: ${{ github.ref }}
-
+          overwrite: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,7 @@ jobs:
           elif [ "${{ matrix.cubit }}" == "2021.11" ]; then
             BASE=Coreform-Cubit-2021.11%2B21637_35609873
           fi
-          fi
+
           echo "COREFORM_BASE_URL=${COREFORM_BASE_URL}/Windows/" >> $GITHUB_ENV
           echo "CUBIT_PKG=${BASE}-Win64.exe" >> $GITHUB_ENV
           echo "CUBIT_SDK_PKG=${BASESDK}-Win64.zip" >> $GITHUB_ENV

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -62,6 +62,9 @@ jobs:
             BASE=Coreform-Cubit-2021.4%2B15017_05893177
           elif [ "${{ matrix.cubit }}" == "2021.5" ]; then
             BASE=Coreform-Cubit-2021.5%2B15962_5043ef39
+          elif [ "${{ matrix.cubit }}" == "2021.11" ]; then
+            BASE=Coreform-Cubit-2021.11%2B21637_35609873
+          fi
           fi
           echo "COREFORM_BASE_URL=${COREFORM_BASE_URL}/Windows/" >> $GITHUB_ENV
           echo "CUBIT_PKG=${BASE}-Win64.exe" >> $GITHUB_ENV

--- a/scripts/unix_share_build.sh
+++ b/scripts/unix_share_build.sh
@@ -215,7 +215,7 @@ function linux_setup_cubit() {
     cd ${FOLDER_PKG}
     $SUDO apt-get install -y ./${CUBIT_PKG}
 
-    if [ "$1" == "2021.3" ] || [ "$1" == "2021.4" ] || [ "$1" == "2021.5" ] ; then
+    if [ "$1" == "2021.3" ] || [ "$1" == "2021.4" ] || [ "$1" == "2021.5" ] || [ "$1" == "2021.11" ] ; then
 	    return
     fi
 


### PR DESCRIPTION
Coreform[ release Cubit 2021.11](https://coreform.com/products/downloads/) recently as mentioned in #129 

This PR adds this version to the matrix of build options and other places in the build scripts so that the plugin can be built for this new version

It appears to build without and version specific additions to the scripts and I have built it over on this fork branch 

I have made a test release on separate fork
https://github.com/shimwell/Cubit-plugin/releases

Release builds performed on Github Actions are the top 3 in this list
https://github.com/shimwell/Cubit-plugin/actions

The linux one appears to fail sometimes, so that is the reason I've added ```overwrite:true``` to the artifact upload. They the action ca be rerun for the same release.