### PR TITLE
add Cubit 22.4 for Debian

### DIFF
--- a/.github/workflows/unix_linux.yml
+++ b/.github/workflows/unix_linux.yml
@@ -48,6 +48,10 @@ jobs:
             os_version: '10.10'  # using a 'string' here as the 0 gets rounded away otherwise
             cubit: 2021.11
 
+          - os: debian
+            os_version: '10.10'  # using a 'string' here as the 0 gets rounded away otherwise
+            cubit: 2022.4
+
 
     name: 'Cubit ${{ matrix.cubit }} Build for ${{ matrix.os }} ${{ matrix.os_version }} of Svalinn Plugin'
 


### PR DESCRIPTION
Add Cubit 2022.4 for Debian to complete the linux builds for a new release.