### PR TITLE
Support degenerate tori with negative major radius

### DIFF
--- a/iGeom/iGeom.cpp
+++ b/iGeom/iGeom.cpp
@@ -273,16 +273,23 @@ void iGeom_createTorus(iGeom_Instance instance,
         STRAIGHT_CURVE_TYPE, v1, v5);
     profile_edges.insert(curve);
 
-    //the first arc
-    curve = GeometryModifyTool::instance()->make_RefEdge(ARC_CURVE_TYPE, v1,
-                                                         v3, &v2_pos);
-    profile_edges.insert(curve);
+    if (major_radius > 0) {
+      //the first arc 
+      curve = GeometryModifyTool::instance()->make_RefEdge(ARC_CURVE_TYPE, v1,
+                                                           v3, &v2_pos);
+      profile_edges.insert(curve);
 
-    //the second arc
-    curve = GeometryModifyTool::instance()->make_RefEdge(ARC_CURVE_TYPE, v3,
-                                                         v5, &v4_pos);
-    profile_edges.insert(curve);
-
+      //the second arc
+      curve = GeometryModifyTool::instance()->make_RefEdge(ARC_CURVE_TYPE, v3,
+                                                           v5, &v4_pos);
+      profile_edges.insert(curve);
+    } else {
+      //only one arc
+      curve = GeometryModifyTool::instance()->make_RefEdge(ARC_CURVE_TYPE, v1,
+                                                           v5, &v3_pos);
+      profile_edges.insert(curve);
+    }
+    
     // make surf from the curves
     // This fails in Cubit
     RefFace *surf = GeometryModifyTool::instance()->make_RefFace(

--- a/iGeom/iGeom.cpp
+++ b/iGeom/iGeom.cpp
@@ -244,7 +244,7 @@ void iGeom_createTorus(iGeom_Instance instance,
                        /*out*/ iBase_EntityHandle *geom_entity,
                        int* err)
 {
-  if (minor_rad >= major_rad) {
+  if (minor_rad >= fabs(major_rad)) {
     // first calculate the 3 control vertices and 2 control points
     double height = sqrt((minor_rad*minor_rad) - (major_rad*major_rad));
     double maxima = major_rad+minor_rad;
@@ -274,6 +274,10 @@ void iGeom_createTorus(iGeom_Instance instance,
     profile_edges.insert(curve);
 
     if (major_radius > 0) {
+      // this type of degenerate torus is defined by a cross-section that
+      // consists of more than 1/2 of a circle, requiring one arc for the
+      // half and one arc for the bottom half
+      
       //the first arc 
       curve = GeometryModifyTool::instance()->make_RefEdge(ARC_CURVE_TYPE, v1,
                                                            v3, &v2_pos);
@@ -284,6 +288,10 @@ void iGeom_createTorus(iGeom_Instance instance,
                                                            v5, &v4_pos);
       profile_edges.insert(curve);
     } else {
+      // this type of degenerate torus is defined by a cross-section that
+      // consists of less than 1/2 of a circle, requiring only a single
+      // arc that passes through the end points and the maxima
+      
       //only one arc
       curve = GeometryModifyTool::instance()->make_RefEdge(ARC_CURVE_TYPE, v1,
                                                            v5, &v3_pos);


### PR DESCRIPTION
This method already supported a degenerate torus with major radius > 0, with a cross-section that includes more than 1/2 of a circle, truncated by a chord across that circle.

This should now support a degenerate torus with major radius < 0, with a cross-section that includes less than 1/2 of a circle, also truncated by a chord across that circle.

Fixes #156 